### PR TITLE
Add public apple accelerate symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,8 +156,10 @@ if(APPLE)
   
   set(ARMA_OS macos)
   
-  set(ARMA_USE_LAPACK true)
-  set(ARMA_USE_BLAS   true)
+  set(ARMA_USE_LAPACK         true)
+  set(ARMA_USE_BLAS           true)
+  set(ARMA_BLAS_CBLAS         true)
+  set(ARMA_BLAS_NO_UNDERSCORE true)
   
   set(ARMA_LIBS ${ARMA_LIBS} "-framework Accelerate")  # or "-framework accelerate" ?
   message(STATUS "MacOS X detected. Added '-framework Accelerate' to compiler flags")

--- a/README.txt
+++ b/README.txt
@@ -33,16 +33,17 @@ Contents
  8: Windows: Compiling & Linking
 
  9: Support for OpenBLAS and Intel MKL
-10: Support for ATLAS
-11: Support for C++11 / C++14 Features
-12: Support for OpenMP
+10: Support for Accelerate
+11: Support for ATLAS
+12: Support for C++11 / C++14 Features
+13: Support for OpenMP
 
-13: API Documentation
-14: API Stability and Versioning
-15: Bug Reports and Frequently Asked Questions
+14: API Documentation
+15: API Stability and Versioning
+16: Bug Reports and Frequently Asked Questions
 
-16: MEX Interface to Octave/Matlab
-17: Related Software
+17: MEX Interface to Octave/Matlab
+18: Related Software
 
 
 
@@ -355,7 +356,15 @@ the CMake based installation. Comment out the lines containing:
 
 
 
-10: Support for ATLAS
+10: Support for Accelerate
+=========================
+
+Armadillo can use Accelerate on OS X and iOS. In order to avoid warning
+about private apis, ARMA_BLAS_CBLAS=1 and  ARMA_BLAS_NO_UNDERSCORE=1 must
+be set. If using cmake, these will be set automatically for you.
+
+
+11: Support for ATLAS
 =====================
 
 Armadillo can use the ATLAS library for faster versions of a subset
@@ -368,7 +377,7 @@ results and/or corrupt memory, leading to random crashes.
 
 
 
-11: Support for C++11 / C++14 Features
+12: Support for C++11 / C++14 Features
 ======================================
 
 Armadillo works with compilers supporting the older C++98 and C++03 standards,
@@ -388,7 +397,7 @@ which creates lots of short lived temporaries that are not handled by auto.
 
 
 
-12: Support for OpenMP
+13: Support for OpenMP
 ======================
 
 Armadillo can use OpenMP to automatically speed up computationally
@@ -403,7 +412,7 @@ may lead to speed regressions on recent processors.
 
 
 
-13: API Documentation
+14: API Documentation
 =====================
 
 Documentation of functions, classes and options is available at:
@@ -415,7 +424,7 @@ which can be viewed with a web browser.
 
 
 
-14: API Stability and Versioning
+15: API Stability and Versioning
 ================================
 
 Each release of Armadillo has its public API (functions, classes, constants)
@@ -451,7 +460,7 @@ implementation details, and may change or be removed without notice.
 
 
 
-15: Bug Reports and Frequently Asked Questions
+16: Bug Reports and Frequently Asked Questions
 ==============================================
 
 Armadillo has gone through extensive testing and has been successfully
@@ -474,7 +483,7 @@ Further information about Armadillo is on the frequently asked questions page:
 
 
 
-16: MEX Interface to Octave/Matlab
+17: MEX Interface to Octave/Matlab
 ==================================
 
 The "mex_interface" folder contains examples of how to interface
@@ -482,7 +491,7 @@ Octave/Matlab with C++ code that uses Armadillo matrices.
 
 
 
-17: Related Software
+18: Related Software
 ====================
 
 * MLPACK: C++ library for machine learning and pattern recognition, built on top of Armadillo.

--- a/include/armadillo_bits/config.hpp
+++ b/include/armadillo_bits/config.hpp
@@ -64,9 +64,17 @@
 // #define ARMA_BLAS_CAPITALS
 //// Uncomment the above line if your BLAS and LAPACK libraries have capitalised function names (eg. ACML on 64-bit Windows)
 
+#if !defined(ARMA_BLAS_CBLAS)
+//#define ARMA_BLAS_CBLAS
+//// ARMA_BLAS_CBLAS should be set if your BLAS library has cblas_ preffixes, like accelerate.
+//// If using cmake, you should have nothing to do. If not, uncomment the above line, or set ARMA_BLAS_CBLAS
+#endif
+
+#if !defined(ARMA_BLAS_NO_UNDERSCORE)
 #define ARMA_BLAS_UNDERSCORE
 //// Uncomment the above line if your BLAS and LAPACK libraries have function names with a trailing underscore.
 //// Conversely, comment it out if the function names don't have a trailing underscore.
+#endif
 
 // #define ARMA_BLAS_LONG
 //// Uncomment the above line if your BLAS and LAPACK libraries use "long" instead of "int"

--- a/include/armadillo_bits/config.hpp.cmake
+++ b/include/armadillo_bits/config.hpp.cmake
@@ -64,9 +64,18 @@
 // #define ARMA_BLAS_CAPITALS
 //// Uncomment the above line if your BLAS and LAPACK libraries have capitalised function names (eg. ACML on 64-bit Windows)
 
+#if !defined(ARMA_BLAS_CBLAS)
+#cmakedefine ARMA_BLAS_CBLAS
+//// ARMA_BLAS_CBLAS should be set if your BLAS library has cblas_ preffixes, like accelerate.
+//// If using cmake, you should have nothing to do.
+#endif
+
+#cmakedefine ARMA_BLAS_NO_UNDERSCORE
+#if !defined(ARMA_BLAS_NO_UNDERSCORE)
 #define ARMA_BLAS_UNDERSCORE
 //// Uncomment the above line if your BLAS and LAPACK libraries have function names with a trailing underscore.
 //// Conversely, comment it out if the function names don't have a trailing underscore.
+#endif
 
 // #define ARMA_BLAS_LONG
 //// Uncomment the above line if your BLAS and LAPACK libraries use "long" instead of "int"

--- a/include/armadillo_bits/def_blas.hpp
+++ b/include/armadillo_bits/def_blas.hpp
@@ -22,7 +22,33 @@
   #pragma message ("WARNING: include the armadillo header before any other header as a workaround")
 #endif
 
-#if !defined(ARMA_BLAS_CAPITALS)
+#if defined(ARMA_BLAS_CBLAS)
+  #define arma_sasum cblas_sasum
+  #define arma_dasum cblas_dasum
+
+  #define arma_snrm2 cblas_snrm2
+  #define arma_dnrm2 cblas_dnrm2
+
+  #define arma_sdot  cblas_sdot
+  #define arma_ddot  cblas_ddot
+
+  #define arma_sgemv cblas_sgemv
+  #define arma_dgemv cblas_dgemv
+  #define arma_cgemv cblas_cgemv
+  #define arma_zgemv cblas_zgemv
+
+  #define arma_sgemm cblas_sgemm
+  #define arma_dgemm cblas_dgemm
+  #define arma_cgemm cblas_cgemm
+  #define arma_zgemm cblas_zgemm
+
+  #define arma_ssyrk cblas_ssyrk
+  #define arma_dsyrk cblas_dsyrk
+
+  #define arma_cherk cblas_cherk
+  #define arma_zherk cblas_zherk
+
+#elif !defined(ARMA_BLAS_CAPITALS)
   
   #define arma_sasum sasum
   #define arma_dasum dasum


### PR DESCRIPTION
Add cblas preffixes and don't default to underscore.

This should mean we are only using public accelerate apis.